### PR TITLE
Remove timezone setting

### DIFF
--- a/changelog/unreleased/remove-timezone-setting.md
+++ b/changelog/unreleased/remove-timezone-setting.md
@@ -1,0 +1,7 @@
+Change: Remove timezone setting
+
+We had a timezone setting in our profile settings bundle. As we're not dealing with a timezone yet
+it would be confusing for the user to have a timezone setting available. We removed it, until we
+have a timezone implementation available in ocis-web.
+
+https://github.com/owncloud/ocis-accounts/pull/33

--- a/pkg/service/v0/settings.go
+++ b/pkg/service/v0/settings.go
@@ -12,33 +12,6 @@ func generateSettingsBundleProfileRequest() settings.SaveSettingsBundleRequest {
 			DisplayName: "Profile",
 			Settings: []*settings.Setting{
 				{
-					SettingKey:  "timezone",
-					DisplayName: "Timezone",
-					Description: "User timezone",
-					Value: &settings.Setting_SingleChoiceValue{
-						SingleChoiceValue: &settings.SingleChoiceListSetting{
-							Options: []*settings.ListOption{
-								{
-									Value: &settings.ListOptionValue{
-										Option: &settings.ListOptionValue_StringValue{
-											StringValue: "Europe/Berlin",
-										},
-									},
-									DisplayValue: "Europe/Berlin",
-								},
-								{
-									Value: &settings.ListOptionValue{
-										Option: &settings.ListOptionValue_StringValue{
-											StringValue: "Asia/Kathmandu",
-										},
-									},
-									DisplayValue: "Asia/Kathmandu",
-								},
-							},
-						},
-					},
-				},
-				{
 					SettingKey:  "language",
 					DisplayName: "Language",
 					Description: "User language",


### PR DESCRIPTION
We will not make use of the timezone setting in the very near future, so it would be confusing for a user to have this setting in their settings UI. Removing it until we use the timezone in ocis-web.