### PR TITLE
handle terms as keywords, remove quotes

### DIFF
--- a/pkg/provider/bleve.go
+++ b/pkg/provider/bleve.go
@@ -52,7 +52,11 @@ func recursiveBuildQuery(n *godata.ParseNode) (query.Query, error) {
 			if n.Children[1].Token.Type != godata.FilterTokenString {
 				return nil, errors.New("equality expected a string on the rhs")
 			}
-			q := bleve.NewTermQuery(n.Children[1].Token.Value)
+			// string tokens are enclosed with 'some string'
+			// ' is escaped as ''
+			// TODO unescape '' as '
+			// http://docs.oasis-open.org/odata/odata/v4.01/cs01/part2-url-conventions/odata-v4.01-cs01-part2-url-conventions.html#sec_URLComponents
+			q := bleve.NewTermQuery(n.Children[1].Token.Value[1 : len(n.Children[1].Token.Value)-1])
 			q.SetField(n.Children[0].Token.Value)
 			return q, nil
 		case "and":

--- a/pkg/service/v0/service.go
+++ b/pkg/service/v0/service.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/CiscoM31/godata"
 	"github.com/blevesearch/bleve"
+	"github.com/blevesearch/bleve/analysis/analyzer/keyword"
 	"github.com/blevesearch/bleve/search/query"
 	"github.com/gofrs/uuid"
 	"github.com/golang/protobuf/ptypes/empty"
@@ -41,6 +42,8 @@ func New(cfg *config.Config) Service {
 	os.MkdirAll(filepath.Join(cfg.Server.AccountsDataPath, "accounts"), 0700)
 
 	mapping := bleve.NewIndexMapping()
+	mapping.DefaultAnalyzer = keyword.Name
+
 	// TODO don't bother to store fields as we will load the account from disk
 	index, err := bleve.New(filepath.Join(cfg.Server.AccountsDataPath, "index.bleve"), mapping)
 	if err != nil {


### PR DESCRIPTION
- handle terms as keywords to not deconstruct emails into individual parts
- unescape string terms