### PR TITLE
Fix the account and group id mismatch in delete group method

### DIFF
--- a/changelog/unreleased/fix-account-group-id.md
+++ b/changelog/unreleased/fix-account-group-id.md
@@ -1,0 +1,8 @@
+Bugfix: Fix the accountId and groupId mismatch in DeleteGroup Method
+
+We've fixed a bug in deleting the groups.
+
+The accountId and GroupId were swapped when removing the member from a group after deleting
+the group.
+
+https://github.com/owncloud/ocis-accounts/pull/60

--- a/pkg/service/v0/groups.go
+++ b/pkg/service/v0/groups.go
@@ -248,8 +248,8 @@ func (s Service) DeleteGroup(c context.Context, in *proto.DeleteGroupRequest, ou
 	// delete memberof relationship in users
 	for i := range g.Members {
 		err = s.RemoveMember(c, &proto.RemoveMemberRequest{
-			GroupId:   g.Members[i].Id,
-			AccountId: id,
+			AccountId: g.Members[i].Id,
+			GroupId:   id,
 		}, g)
 		if err != nil {
 			s.log.Error().Err(err).Str("groupid", id).Str("accountid", g.Members[i].Id).Msg("could not remove account memberof, skipping")


### PR DESCRIPTION
The accountId and GroupId were swapped when removing the member from a group after deleting
the group. That was fixed  in this PR.                                                            
