### PR TITLE
fix password related segfaults

### DIFF
--- a/changelog/unreleased/fix-segfault.md
+++ b/changelog/unreleased/fix-segfault.md
@@ -1,4 +1,4 @@
-Bugfix: Prevent segfault when no password is set.
+Bugfix: Prevent segfault when no password is set
 
 Passwords are stored in a dedicated child struct of an account. We fixed several segfault conditions where the methods would try to unset a password when that child struct was not existing.
 

--- a/changelog/unreleased/fix-segfault.md
+++ b/changelog/unreleased/fix-segfault.md
@@ -1,0 +1,5 @@
+Bugfix: Prevent segfault when no password is set.
+
+Passwords are stored in a dedicated child struct of an account. We fixed several segfault conditions where the methods would try to unset a password when that child struct was not existing.
+
+https://github.com/owncloud/ocis-accounts/pull/65

--- a/changelog/unreleased/tighten-screws.md
+++ b/changelog/unreleased/tighten-screws.md
@@ -1,0 +1,5 @@
+Change: Tighten screws on usernames and email addresses
+
+In order to match accounts to the OIDC claims we currently rely on the email address or username to be present. We force both to match the [W3C recommended regex](https://www.w3.org/TR/2016/REC-html51-20161101/sec-forms.html#valid-e-mail-address) with usernames having to start with a character or `_`. This allows the username to be presented and used in ACLs when integrating the os with the glauth LDAP service of ocis.
+
+https://github.com/owncloud/ocis-accounts/pull/65

--- a/pkg/proto/v0/accounts.pb.micro_test.go
+++ b/pkg/proto/v0/accounts.pb.micro_test.go
@@ -405,7 +405,9 @@ func TestCreateAccountInvalidUserName(t *testing.T) {
 		_, err := createAccount(t, userName)
 
 		// Should give error
-		checkError(t, err)
+		if err == nil {
+			t.Fatalf("Expected an Error when creating user '%s' but got nil", userName)
+		}
 	}
 
 	// resp should have the same number of accounts

--- a/pkg/proto/v0/accounts.pb.micro_test.go
+++ b/pkg/proto/v0/accounts.pb.micro_test.go
@@ -389,6 +389,11 @@ func TestCreateExistingUser(t *testing.T) {
 // All tests fail after running this
 // https://github.com/owncloud/ocis-accounts/issues/62
 func TestCreateAccountInvalidUserName(t *testing.T) {
+
+	resp, err := listAccounts(t)
+	checkError(t, err)
+	numAccounts := len(resp.GetAccounts())
+
 	testData := []string{
 		"",
 		"0",
@@ -403,11 +408,11 @@ func TestCreateAccountInvalidUserName(t *testing.T) {
 		checkError(t, err)
 	}
 
-	// This throws a error in server
-	// resp contains no accounts
-	resp, _ := listAccounts(t)
+	// resp should have the same number of accounts
+	resp, err = listAccounts(t)
+	checkError(t, err)
 
-	assert.Equal(t, 0, len(resp.GetAccounts()))
+	assert.Equal(t, numAccounts, len(resp.GetAccounts()))
 
 	cleanUp(t)
 }


### PR DESCRIPTION
Passwords are stored in a dedicated child struct of an account. We fixed several segfault conditions where the methods would try to unset a password when that child struct was not existing.