### PR TITLE
fix index mapping

### DIFF
--- a/changelog/unreleased/fix-index-mapping.md
+++ b/changelog/unreleased/fix-index-mapping.md
@@ -1,0 +1,5 @@
+Enhancement: Add simple user listing UI
+
+We added an extension for ocis-web that shows a simple list of all existing users.
+
+https://github.com/owncloud/ocis-accounts/pull/51

--- a/pkg/provider/bleve.go
+++ b/pkg/provider/bleve.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/CiscoM31/godata"
 	"github.com/blevesearch/bleve"
@@ -35,9 +36,11 @@ func recursiveBuildQuery(n *godata.ParseNode) (query.Query, error) {
 			if n.Children[1].Token.Type != godata.FilterTokenString {
 				return nil, errors.New("startswith expected a string as the second param")
 			}
-			q := bleve.NewTermQuery(n.Children[1].Token.Value)
+			q := bleve.NewPrefixQuery(n.Children[1].Token.Value)
 			q.SetField(n.Children[0].Token.Value)
 			return q, nil
+			// TODO contains as regex?
+			// TODO endswith as regex?
 		default:
 			return nil, godata.NotImplementedError(n.Token.Value + " is not implemented.")
 		}
@@ -52,11 +55,20 @@ func recursiveBuildQuery(n *godata.ParseNode) (query.Query, error) {
 				return nil, errors.New("equality expected a literal on the lhs")
 			}
 			if n.Children[1].Token.Type == godata.FilterTokenString {
-				// string tokens are enclosed with 'some string'
-				// ' is escaped as ''
-				// TODO unescape '' as '
-				// http://docs.oasis-open.org/odata/odata/v4.01/cs01/part2-url-conventions/odata-v4.01-cs01-part2-url-conventions.html#sec_URLComponents
-				q := bleve.NewTermQuery(n.Children[1].Token.Value[1 : len(n.Children[1].Token.Value)-1])
+				// for escape rules see http://docs.oasis-open.org/odata/odata/v4.01/cs01/part2-url-conventions/odata-v4.01-cs01-part2-url-conventions.html#sec_URLComponents
+				// remove enclosing ' of string tokens (looks like 'some ol'' string')
+				value := n.Children[1].Token.Value[1 : len(n.Children[1].Token.Value)-1]
+				// unescape '' as '
+				unascaped := strings.ReplaceAll(value, "''", "'")
+				// use a match query, so the field mapping, e.g. lowercase is applied to the value
+				// remember we defined the field mapping for `preferred_name` to be lowercase
+				// a term query like `preferred_name eq 'Artur'` would use `Artur` to search in the index and come up empty
+				// a match query will apply the field mapping (lowercasing `Artur` to `artur`) before doing the search
+				// TODO there is a mismatch between the LDAP and odata filters:
+				// - LDAP matching rules depend on the attribute: see https://ldapwiki.com/wiki/MatchingRule
+				// - odata has functions like `startswith`, `contains`, `tolower`, `toupper`, `matchesPattern` andy more: see http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_BuiltinQueryFunctions
+				// - ocis-glauth should do the mapping between LDAP and odata filter
+				q := bleve.NewMatchQuery(unascaped)
 				q.SetField(n.Children[0].Token.Value)
 				return q, nil
 			} else if n.Children[1].Token.Type == godata.FilterTokenInteger {

--- a/pkg/service/v0/accounts.go
+++ b/pkg/service/v0/accounts.go
@@ -48,7 +48,10 @@ func (s Service) indexAccounts(path string) (err error) {
 		return
 	}
 	for _, file := range list {
-		_ = s.indexAccount(file.Name())
+		err = s.indexAccount(file.Name())
+		if err != nil {
+			s.log.Error().Err(err).Str("file", file.Name()).Msg("could not index account")
+		}
 	}
 
 	return

--- a/pkg/service/v0/groups.go
+++ b/pkg/service/v0/groups.go
@@ -30,7 +30,10 @@ func (s Service) indexGroups(path string) (err error) {
 		return
 	}
 	for _, file := range list {
-		_ = s.indexGroup(file.Name())
+		err = s.indexGroup(file.Name())
+		if err != nil {
+			s.log.Error().Err(err).Str("file", file.Name()).Msg("could not index account")
+		}
 	}
 
 	return


### PR DESCRIPTION
The index mapping was not being used because we were not using the right blevesearch TypeField, leading to username like properties like `preferred_name` and `on_premises_sam_account_name` to be case sensitive.

fixes https://github.com/owncloud/ocis-accounts/issues/73

## how do test

1. `ACCOUNTS_LOG_LEVEL=debug go run cmd/ocis-accounts/main.go server`
2. `micro call com.owncloud.api.accounts AccountsService.ListAccounts "{\"query\":\"preferred_name eq 'einstein'\"}"`
3. `micro call com.owncloud.api.accounts AccountsService.ListAccounts "{\"query\":\"preferred_name eq 'EiNsTeIn'\"}"`

both calls should return the account.