### PR TITLE
Unescape value for prefix query

### DIFF
--- a/changelog/unreleased/fix-prefix-query.md
+++ b/changelog/unreleased/fix-prefix-query.md
@@ -1,0 +1,5 @@
+Bugfix: Unescape value for prefix query
+
+Prefix queries also need to unescape token values like `'some ''ol string'` to `some 'ol string` before using it in a prefix query
+
+https://github.com/owncloud/ocis-accounts/pull/76


### PR DESCRIPTION
Prefix queries also need to unescape token values like `'some ''ol string'` to `some 'ol string` before using it in a prefix query