### PR TITLE
Add permissions for roles

### DIFF
--- a/changelog/unreleased/add-language-permissions-to-default-roles.md
+++ b/changelog/unreleased/add-language-permissions-to-default-roles.md
@@ -1,0 +1,6 @@
+Change: Add permissions for language to default roles
+
+ocis-settings has default roles and exposes the respective bundle uuids. We now added
+permissions for reading/writing the preferred language to the default roles.
+
+https://github.com/owncloud/ocis-accounts/pull/88

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/owncloud/ocis-pkg/v2 v2.3.0
-	github.com/owncloud/ocis-settings v0.1.1-0.20200819091309-d59cdd5469ac
+	github.com/owncloud/ocis-settings v0.1.1-0.20200819111829-a987d53702a8
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/restic/calens v0.2.0
 	github.com/rs/zerolog v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -599,6 +599,7 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.0.0 h1:21MVWPKDphxa7ineQQTrCU5brh7OuVVAzGOCnnCPtE8=
 github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -723,8 +724,10 @@ github.com/markbates/willie v1.0.9/go.mod h1:fsrFVWl91+gXpx/6dv715j7i11fYPfZ9ZGf
 github.com/marten-seemann/chacha20 v0.2.0/go.mod h1:HSdjFau7GzYRj+ahFNwsO3ouVJr1HFkWoEwNDb4TMtE=
 github.com/marten-seemann/qpack v0.1.0/go.mod h1:LFt1NU/Ptjip0C2CPkhimBz5CGE3WGDAUWqna+CNTrI=
 github.com/marten-seemann/qtls v0.4.1/go.mod h1:pxVXcHHw1pNIt8Qo0pwSYQEoZ8yYOOPXTCZLQQunvRc=
+github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -868,6 +871,10 @@ github.com/owncloud/ocis-pkg/v2 v2.3.0 h1:bdDgfPkPdL3D6bGKhQ56pfwT1XdiKBtQ34qErV
 github.com/owncloud/ocis-pkg/v2 v2.3.0/go.mod h1:FSzIvhx9HcZcq4jgNaDowNvM7PTX/XCyoMvyfzidUpE=
 github.com/owncloud/ocis-settings v0.1.1-0.20200819091309-d59cdd5469ac h1:QGIa2920ZNNgcMVgLXrk9C/reDViVHFG1troCFu9gok=
 github.com/owncloud/ocis-settings v0.1.1-0.20200819091309-d59cdd5469ac/go.mod h1:pvB0Mk24i0Gf6bmiIFEINgOFvViXtzVyossovxMRv0s=
+github.com/owncloud/ocis-settings v0.1.1-0.20200819105511-cb578e5039f4 h1:Y+ZHRPL04FFwvelhdkvWyXhAbT7l5tJmAEruAdyRZ80=
+github.com/owncloud/ocis-settings v0.1.1-0.20200819105511-cb578e5039f4/go.mod h1:pvB0Mk24i0Gf6bmiIFEINgOFvViXtzVyossovxMRv0s=
+github.com/owncloud/ocis-settings v0.1.1-0.20200819111829-a987d53702a8 h1:Et/p4+iG1GnnPZhz5HGPb0HaOsbBkwL6rI72+fr1YDc=
+github.com/owncloud/ocis-settings v0.1.1-0.20200819111829-a987d53702a8/go.mod h1:pvB0Mk24i0Gf6bmiIFEINgOFvViXtzVyossovxMRv0s=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/parnurzeal/gorequest v0.2.15/go.mod h1:3Kh2QUMJoqw3icWAecsyzkpY7UzRfDhbRdTjtNwNiUE=

--- a/pkg/service/v0/settings.go
+++ b/pkg/service/v0/settings.go
@@ -6,6 +6,7 @@ import (
 	mclient "github.com/micro/go-micro/v2/client"
 	olog "github.com/owncloud/ocis-pkg/v2/log"
 	settings "github.com/owncloud/ocis-settings/pkg/proto/v0"
+	ssvc "github.com/owncloud/ocis-settings/pkg/service/v0"
 )
 
 const (
@@ -28,6 +29,17 @@ func RegisterSettingsBundles(l *olog.Logger) {
 			l.Err(err).Str("bundle", bundleRequests[i].Bundle.Id).Msg("Error registering bundle")
 		} else {
 			l.Info().Str("bundle", res.Bundle.Id).Msg("Successfully registered bundle")
+		}
+	}
+
+	permissionRequests := generateProfilePermissionsRequests()
+	for i := range permissionRequests {
+		res, err := service.AddSettingToBundle(context.Background(), &permissionRequests[i])
+		bundleId := permissionRequests[i].BundleId
+		if err != nil {
+			l.Err(err).Str("bundle", bundleId).Str("setting", permissionRequests[i].Setting.Id).Msg("Error adding setting to bundle")
+		} else {
+			l.Info().Str("bundle", bundleId).Str("setting", res.Setting.Id).Msg("Successfully added setting to bundle")
 		}
 	}
 }
@@ -116,6 +128,139 @@ func generateBundleProfileRequest() settings.SaveBundleRequest {
 						Type: settings.Resource_TYPE_USER,
 					},
 					Value: &languageSetting,
+				},
+			},
+		},
+	}
+}
+
+func generateProfilePermissionsRequests() []settings.AddSettingToBundleRequest {
+	// TODO: we don't want to set up permissions for settings manually in the future. Instead each setting should come with
+	// a set of default permissions for the default roles (guest, user, admin).
+	return []settings.AddSettingToBundleRequest{
+		{
+			BundleId: ssvc.BundleUUIDRoleAdmin,
+			Setting: &settings.Setting{
+				Id:          "7d81f103-0488-4853-bce5-98dcce36d649",
+				Name:        "language-create",
+				DisplayName: "Permission to set the language",
+				Resource: &settings.Resource{
+					Type: settings.Resource_TYPE_SETTING,
+					Id:   settingUUIDProfileLanguage,
+				},
+				Value: &settings.Setting_PermissionValue{
+					PermissionValue: &settings.Permission{
+						Operation:  settings.Permission_OPERATION_CREATE,
+						Constraint: settings.Permission_CONSTRAINT_OWN,
+					},
+				},
+			},
+		},
+		{
+			BundleId: ssvc.BundleUUIDRoleAdmin,
+			Setting: &settings.Setting{
+				Id:          "04ef2fd3-e724-48f6-a411-129dd461c820",
+				Name:        "language-read",
+				DisplayName: "Permission to read the language",
+				Resource: &settings.Resource{
+					Type: settings.Resource_TYPE_SETTING,
+					Id:   settingUUIDProfileLanguage,
+				},
+				Value: &settings.Setting_PermissionValue{
+					PermissionValue: &settings.Permission{
+						Operation:  settings.Permission_OPERATION_READ,
+						Constraint: settings.Permission_CONSTRAINT_OWN,
+					},
+				},
+			},
+		},
+		{
+			BundleId: ssvc.BundleUUIDRoleAdmin,
+			Setting: &settings.Setting{
+				Id:          "30ac1e63-10e2-4ef8-bf0a-941cd5b56c5c",
+				Name:        "language-update",
+				DisplayName: "Permission to update the language",
+				Resource: &settings.Resource{
+					Type: settings.Resource_TYPE_SETTING,
+					Id:   settingUUIDProfileLanguage,
+				},
+				Value: &settings.Setting_PermissionValue{
+					PermissionValue: &settings.Permission{
+						Operation:  settings.Permission_OPERATION_UPDATE,
+						Constraint: settings.Permission_CONSTRAINT_OWN,
+					},
+				},
+			},
+		},
+		{
+			BundleId: ssvc.BundleUUIDRoleUser,
+			Setting: &settings.Setting{
+				Id:          "640e00d2-4df8-41bd-b1c2-9f30a01e0e99",
+				Name:        "language-create",
+				DisplayName: "Permission to set the language",
+				Resource: &settings.Resource{
+					Type: settings.Resource_TYPE_SETTING,
+					Id:   settingUUIDProfileLanguage,
+				},
+				Value: &settings.Setting_PermissionValue{
+					PermissionValue: &settings.Permission{
+						Operation:  settings.Permission_OPERATION_CREATE,
+						Constraint: settings.Permission_CONSTRAINT_OWN,
+					},
+				},
+			},
+		},
+		{
+			BundleId: ssvc.BundleUUIDRoleUser,
+			Setting: &settings.Setting{
+				Id:          "dcaeb961-da25-46f2-9892-731603a20d3b",
+				Name:        "language-read",
+				DisplayName: "Permission to read the language",
+				Resource: &settings.Resource{
+					Type: settings.Resource_TYPE_SETTING,
+					Id:   settingUUIDProfileLanguage,
+				},
+				Value: &settings.Setting_PermissionValue{
+					PermissionValue: &settings.Permission{
+						Operation:  settings.Permission_OPERATION_READ,
+						Constraint: settings.Permission_CONSTRAINT_OWN,
+					},
+				},
+			},
+		},
+		{
+			BundleId: ssvc.BundleUUIDRoleUser,
+			Setting: &settings.Setting{
+				Id:          "e43f364c-ffa5-4080-9621-0d186632a169",
+				Name:        "language-update",
+				DisplayName: "Permission to update the language",
+				Resource: &settings.Resource{
+					Type: settings.Resource_TYPE_SETTING,
+					Id:   settingUUIDProfileLanguage,
+				},
+				Value: &settings.Setting_PermissionValue{
+					PermissionValue: &settings.Permission{
+						Operation:  settings.Permission_OPERATION_UPDATE,
+						Constraint: settings.Permission_CONSTRAINT_OWN,
+					},
+				},
+			},
+		},
+		{
+			BundleId: ssvc.BundleUUIDRoleGuest,
+			Setting: &settings.Setting{
+				Id:          "ca878636-8b1a-4fae-8282-8617a4c13597",
+				Name:        "language-read",
+				DisplayName: "Permission to read the language",
+				Resource: &settings.Resource{
+					Type: settings.Resource_TYPE_SETTING,
+					Id:   settingUUIDProfileLanguage,
+				},
+				Value: &settings.Setting_PermissionValue{
+					PermissionValue: &settings.Permission{
+						Operation:  settings.Permission_OPERATION_READ,
+						Constraint: settings.Permission_CONSTRAINT_OWN,
+					},
 				},
 			},
 		},

--- a/pkg/service/v0/settings.go
+++ b/pkg/service/v0/settings.go
@@ -35,11 +35,11 @@ func RegisterSettingsBundles(l *olog.Logger) {
 	permissionRequests := generateProfilePermissionsRequests()
 	for i := range permissionRequests {
 		res, err := service.AddSettingToBundle(context.Background(), &permissionRequests[i])
-		bundleId := permissionRequests[i].BundleId
+		bundleID := permissionRequests[i].BundleId
 		if err != nil {
-			l.Err(err).Str("bundle", bundleId).Str("setting", permissionRequests[i].Setting.Id).Msg("Error adding setting to bundle")
+			l.Err(err).Str("bundle", bundleID).Str("setting", permissionRequests[i].Setting.Id).Msg("Error adding setting to bundle")
 		} else {
-			l.Info().Str("bundle", bundleId).Str("setting", res.Setting.Id).Msg("Successfully added setting to bundle")
+			l.Info().Str("bundle", bundleID).Str("setting", res.Setting.Id).Msg("Successfully added setting to bundle")
 		}
 	}
 }


### PR DESCRIPTION
We have default roles in ocis-settings and the respective bundle uuids are exposed there as constants. This PR adds permissions for the language to the default roles. We're not filtering for those, though, so this is only setting up the data basis for permission filtering later on.