### PR TITLE
Explicitly run `make protobuf` when running `make build`

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -105,7 +105,7 @@ def testing(ctx):
         'image': 'webhippie/golang:1.13',
         'pull': 'always',
         'commands': [
-          'make build',
+          'make protobuf build',
         ],
         'volumes': [
           {
@@ -205,7 +205,7 @@ def docker(ctx, arch):
         'image': 'webhippie/golang:1.13',
         'pull': 'always',
         'commands': [
-          'make build',
+          'make protobuf build',
         ],
         'volumes': [
           {
@@ -291,7 +291,7 @@ def UITests(ctx, ocisBranch, ocisCommitId, phoenixBranch, phoenixCommitId):
        'image': 'webhippie/golang:1.13',
        'pull': 'always',
        'commands': [
-         'make build',
+         'make protobuf build',
        ],
        'volumes': [
          {


### PR DESCRIPTION
There are weird issues where randomly protoc compilations happen
although they should not be triggered. As those don't run through the
makefile but somehow differently, the prerequisites are not built first
(protoc plugins have to be fetched, which happens in the `make
protobuf` step).

