### PR TITLE
Add default user moss and assign default roles to builtin users

### DIFF
--- a/changelog/unreleased/builtin-regular-users.md
+++ b/changelog/unreleased/builtin-regular-users.md
@@ -1,0 +1,5 @@
+Change: Set user role on builtin users
+
+We now set the default `user` role on our builtin users.
+
+https://github.com/owncloud/ocis-accounts/pull/102

--- a/changelog/unreleased/new-admin-user.md
+++ b/changelog/unreleased/new-admin-user.md
@@ -1,0 +1,5 @@
+Change: Add new builtin admin user
+
+We added a new builtin user `moss` and assigned the admin role.
+
+https://github.com/owncloud/ocis-accounts/pull/102

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/owncloud/ocis-pkg/v2 v2.4.0
-	github.com/owncloud/ocis-settings v0.3.0
+	github.com/owncloud/ocis-settings v0.3.2-0.20200828130413-0cc0f5bf26fe
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/restic/calens v0.2.0
 	github.com/rs/zerolog v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -871,11 +871,14 @@ github.com/owncloud/ocis-pkg/v2 v2.2.2-0.20200812103920-db41b5a3d14d h1:eruHqxLf
 github.com/owncloud/ocis-pkg/v2 v2.2.2-0.20200812103920-db41b5a3d14d/go.mod h1:FSzIvhx9HcZcq4jgNaDowNvM7PTX/XCyoMvyfzidUpE=
 github.com/owncloud/ocis-pkg/v2 v2.3.0 h1:bdDgfPkPdL3D6bGKhQ56pfwT1XdiKBtQ34qErVyXzys=
 github.com/owncloud/ocis-pkg/v2 v2.3.0/go.mod h1:FSzIvhx9HcZcq4jgNaDowNvM7PTX/XCyoMvyfzidUpE=
+github.com/owncloud/ocis-pkg/v2 v2.4.0 h1:/3ZOd4txtwjiNKJA9iLT9BjrJw5YgHSX13fQR4BYfGY=
 github.com/owncloud/ocis-pkg/v2 v2.4.0/go.mod h1:FSzIvhx9HcZcq4jgNaDowNvM7PTX/XCyoMvyfzidUpE=
 github.com/owncloud/ocis-settings v0.2.0 h1:pncwKQQdWGyUwO/+O10vcIrgGWWBAF9/PPWOCnD0DU4=
 github.com/owncloud/ocis-settings v0.2.0/go.mod h1:7+fRwpXe+njcsO0d9Bpxx3V8ZsF99JrL6jCeD9QuxUk=
 github.com/owncloud/ocis-settings v0.3.0 h1:w1wdqJiMtRNJ5B7sQemvtFQQod31G6dR468GxAV0Y2g=
 github.com/owncloud/ocis-settings v0.3.0/go.mod h1:vRge9QDkOsc6j76gPBmZs1Z5uOPrV4DIkZCgZCEFwBA=
+github.com/owncloud/ocis-settings v0.3.2-0.20200828130413-0cc0f5bf26fe h1:kiU5lz12R0LNJE1/zI2vxesZPWm6BvSO7hvZC8yOoAc=
+github.com/owncloud/ocis-settings v0.3.2-0.20200828130413-0cc0f5bf26fe/go.mod h1:vRge9QDkOsc6j76gPBmZs1Z5uOPrV4DIkZCgZCEFwBA=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/parnurzeal/gorequest v0.2.15/go.mod h1:3Kh2QUMJoqw3icWAecsyzkpY7UzRfDhbRdTjtNwNiUE=

--- a/pkg/service/v0/option.go
+++ b/pkg/service/v0/option.go
@@ -3,6 +3,7 @@ package service
 import (
 	"github.com/owncloud/ocis-accounts/pkg/config"
 	"github.com/owncloud/ocis-pkg/v2/log"
+	settings "github.com/owncloud/ocis-settings/pkg/proto/v0"
 )
 
 // Option defines a single option function.
@@ -10,8 +11,9 @@ type Option func(o *Options)
 
 // Options defines the available options for this package.
 type Options struct {
-	Logger log.Logger
-	Config *config.Config
+	Logger      log.Logger
+	Config      *config.Config
+	RoleService settings.RoleService
 }
 
 func newOptions(opts ...Option) Options {
@@ -35,5 +37,12 @@ func Logger(val log.Logger) Option {
 func Config(val *config.Config) Option {
 	return func(o *Options) {
 		o.Config = val
+	}
+}
+
+// RoleService provides a function to set the role service option.
+func RoleService(val settings.RoleService) Option {
+	return func(o *Options) {
+		o.RoleService = val
 	}
 }

--- a/pkg/service/v0/service.go
+++ b/pkg/service/v0/service.go
@@ -31,6 +31,10 @@ func New(opts ...Option) (s *Service, err error) {
 	options := newOptions(opts...)
 	logger := options.Logger
 	cfg := options.Config
+	roleService := options.RoleService
+	if roleService == nil {
+		roleService = settings.NewRoleService("com.owncloud.api.settings", mgrpc.NewClient())
+	}
 	// read all user and group records
 
 	accountsDir := filepath.Join(cfg.Server.AccountsDataPath, "accounts")
@@ -169,19 +173,18 @@ func New(opts ...Option) (s *Service, err error) {
 				}
 
 				// set role for admin users and regular users
-				rs := settings.NewRoleService("com.owncloud.api.settings", mgrpc.NewClient())
-				assignRoleToUser("058bff95-6708-4fe5-91e4-9ea3d377588b", settings_svc.BundleUUIDRoleAdmin, rs, logger)
+				assignRoleToUser("058bff95-6708-4fe5-91e4-9ea3d377588b", settings_svc.BundleUUIDRoleAdmin, roleService, logger)
 				for _, accountID := range []string{
 					"058bff95-6708-4fe5-91e4-9ea3d377588b",//moss
 				} {
-					assignRoleToUser(accountID, settings_svc.BundleUUIDRoleAdmin, rs, logger)
+					assignRoleToUser(accountID, settings_svc.BundleUUIDRoleAdmin, roleService, logger)
 				}
 				for _, accountID := range []string{
 					"4c510ada-c86b-4815-8820-42cdf82c3d51",//einstein
 					"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",//marie
 					"932b4540-8d16-481e-8ef4-588e4b6b151c",//richard
 				} {
-					assignRoleToUser(accountID, settings_svc.BundleUUIDRoleUser, rs, logger)
+					assignRoleToUser(accountID, settings_svc.BundleUUIDRoleUser, roleService, logger)
 				}
 			}
 		} else if !fi.IsDir() {


### PR DESCRIPTION
This PR adds a new default user "Maurice Moss" with credentials `moss:vista`. It also assigns the default `user` role to `einstein`, `marie` und `richard` and the default `admin` role to the new `moss` user.