### PR TITLE
change hashing algorithm from SHA-512 to bcrypt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c // indirect
 	github.com/tredoe/osutil v1.0.5
+	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 	google.golang.org/genproto v0.0.0-20200527145253-8367513e4ece
 	google.golang.org/protobuf v1.25.0

--- a/pkg/service/v0/accounts.go
+++ b/pkg/service/v0/accounts.go
@@ -23,15 +23,13 @@ import (
 	settings "github.com/owncloud/ocis-settings/pkg/proto/v0"
 	settings_svc "github.com/owncloud/ocis-settings/pkg/service/v0"
 	"github.com/rs/zerolog"
-	"github.com/tredoe/osutil/user/crypt"
+	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/genproto/protobuf/field_mask"
 	"google.golang.org/protobuf/types/known/timestamppb"
+)
 
-	// register crypt functions
-	_ "github.com/tredoe/osutil/user/crypt/apr1_crypt"
-	_ "github.com/tredoe/osutil/user/crypt/md5_crypt"
-	_ "github.com/tredoe/osutil/user/crypt/sha256_crypt"
-	_ "github.com/tredoe/osutil/user/crypt/sha512_crypt"
+const (
+	bcryptCost = 12
 )
 
 // accLock mutually exclude readers from writers on account files
@@ -153,8 +151,8 @@ func (s Service) passwordIsValid(hash string, pwd string) (ok bool) {
 		}
 	}()
 
-	c := crypt.NewFromHash(hash)
-	return c.Verify(hash, []byte(pwd)) == nil
+	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(pwd))
+	return err == nil
 }
 
 func (s Service) hasAccountManagementPermissions(ctx context.Context) bool {
@@ -326,11 +324,12 @@ func (s Service) CreateAccount(ctx context.Context, in *proto.CreateAccountReque
 	if acc.PasswordProfile != nil {
 		if acc.PasswordProfile.Password != "" {
 			// encrypt password
-			c := crypt.New(crypt.SHA512)
-			if acc.PasswordProfile.Password, err = c.Generate([]byte(acc.PasswordProfile.Password), nil); err != nil {
+			hash, err := bcrypt.GenerateFromPassword([]byte(acc.PasswordProfile.Password), bcryptCost)
+			if err != nil {
 				s.log.Error().Err(err).Str("id", id).Msg("could not hash password")
 				return merrors.InternalServerError(s.id, "could not hash password: %v", err.Error())
 			}
+			acc.PasswordProfile.Password = string(hash)
 		}
 
 		if err := passwordPoliciesValid(acc.PasswordProfile.PasswordPolicies); err != nil {
@@ -429,13 +428,13 @@ func (s Service) UpdateAccount(ctx context.Context, in *proto.UpdateAccountReque
 		}
 		if in.Account.PasswordProfile.Password != "" {
 			// encrypt password
-			c := crypt.New(crypt.SHA512)
-			if out.PasswordProfile.Password, err = c.Generate([]byte(in.Account.PasswordProfile.Password), nil); err != nil {
+			hash, err := bcrypt.GenerateFromPassword([]byte(in.Account.PasswordProfile.Password), bcryptCost)
+			if err != nil {
 				in.Account.PasswordProfile.Password = ""
 				s.log.Error().Err(err).Str("id", id).Msg("could not hash password")
 				return merrors.InternalServerError(s.id, "could not hash password: %v", err.Error())
 			}
-
+			out.PasswordProfile.Password = string(hash)
 			in.Account.PasswordProfile.Password = ""
 		}
 

--- a/pkg/service/v0/service.go
+++ b/pkg/service/v0/service.go
@@ -60,7 +60,7 @@ func New(opts ...Option) (s *Service, err error) {
 						UidNumber:                20000,
 						GidNumber:                30000,
 						PasswordProfile: &proto.PasswordProfile{
-							Password: "$6$rounds=35210$sa1u5Pmfo4cr23Vw$RJNGElaDB1D3xorWkfTEGm2Ko.o2QL3E0cimKx23MNxVWVFSkUUeRoC7FqC4RzYDNQBD6cKzovTEaDD.8TDkD.",
+							Password: "$2a$12$sR2Btgz4iuS08X7zHboPT.ZyT6NcPRzV9pX/kaGF9scTxgJ.wia6a",
 						},
 						AccountEnabled: true,
 						MemberOf: []*proto.Group{
@@ -79,7 +79,7 @@ func New(opts ...Option) (s *Service, err error) {
 						UidNumber:                20001,
 						GidNumber:                30000,
 						PasswordProfile: &proto.PasswordProfile{
-							Password: "$6$rounds=81434$sa1u5Pmfo4cr23Vw$W78cyL884GmuvDpxYPvSRBVzEj02T5QhTTcI8Dv4IKvMooDFGv4bwaWMkH9HfJ0wgpEBW7Lp.4Cad0xE/MYSg1",
+							Password: "$2a$12$bgoFRgqNqwrzYDmVOuh7GuR0FhWtBJpvAenmQnE1n//cgH3B9GCR6",
 						},
 						AccountEnabled: true,
 						MemberOf: []*proto.Group{
@@ -98,7 +98,7 @@ func New(opts ...Option) (s *Service, err error) {
 						UidNumber:                20002,
 						GidNumber:                30000,
 						PasswordProfile: &proto.PasswordProfile{
-							Password: "$6$rounds=5524$sa1u5Pmfo4cr23Vw$58bQVL/JeUlwM0RY21YKAFMvKvwKLLysGllYXox.vwKT5dHMwdzJjCxwTDMnB2o2pwexC8o/iOXyP2zrhALS40",
+							Password: "$2a$12$QmROpFZdd8R0Zvqy/Ee.k.g2kHUxI3Nl7xoiuM/G7hCAC.VO7ZXW6",
 						},
 						AccountEnabled: true,
 						MemberOf: []*proto.Group{
@@ -118,7 +118,7 @@ func New(opts ...Option) (s *Service, err error) {
 						UidNumber:                20003,
 						GidNumber:                30000,
 						PasswordProfile: &proto.PasswordProfile{
-							Password: "$6$rounds=47068$lhw6odzXW0LTk/ao$GgxS.pIgP8jawLJBAiyNor2FrWzrULF95PwspRkli2W3VF.4HEwTYlQfRXbNQBMjNCEcEYlgZo3a.kRz2k2N0/",
+							Password: "$2a$12$HIzEG9Cum21OEn54KJ0U2OB8jL4f8TkZfGTMJT/mkT6axHl1FW0eK",
 						},
 						AccountEnabled: true,
 						MemberOf: []*proto.Group{
@@ -135,7 +135,7 @@ func New(opts ...Option) (s *Service, err error) {
 						UidNumber:                10000,
 						GidNumber:                15000,
 						PasswordProfile: &proto.PasswordProfile{
-							Password: "$6$rounds=9746$sa1u5Pmfo4cr23Vw$2hnwpkTvUkWX0v6mh8Aw1pbzEXa9EUJzmrey4g2W/8arwWCwhteqU//3aWnA3S0d5T21fOKYteoqlsN1IbTcN.",
+							Password: "$2a$12$GtUAb7GTEtHtHGX8uK54UekNXCPrjYx7WuDXd0v4xCkZq1kpnyF5O",
 						},
 						AccountEnabled: true,
 						MemberOf: []*proto.Group{
@@ -151,7 +151,7 @@ func New(opts ...Option) (s *Service, err error) {
 						UidNumber:                10001,
 						GidNumber:                15000,
 						PasswordProfile: &proto.PasswordProfile{
-							Password: "$6$rounds=91087$sa1u5Pmfo4cr23Vw$wPC3BbMTbP/ytlo0p.f99zJifyO70AUCdKIK9hkhwutBKGCirLmZs/MsWAG6xHjVvmnmHN5NoON7FUGv5pPaN.",
+							Password: "$2a$12$HIzEG9Cum21OEn54KJ0U2OB8jL4f8TkZfGTMJT/mkT6axHl1FW0eK",
 						},
 						AccountEnabled: true,
 						MemberOf: []*proto.Group{


### PR DESCRIPTION
Even though SHA-512 is currently considered a secure algorithm it is not the best choice for password hashing.
As this commit introduces a breaking change it is best to introduce it as early as possible to prevent us from having to implement a migration strategy

- [ ] Change the password hash for the reva user.
- [ ] Add changelog