### PR TITLE
add command to list versions of running accounts services

### DIFF
--- a/changelog/unreleased/add-version-command.md
+++ b/changelog/unreleased/add-version-command.md
@@ -1,0 +1,5 @@
+Enhancement: add a command to list the versions of running instances
+
+Added a micro command to list the versions of running accounts services.
+
+https://github.com/owncloud/product/issues/226

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -37,6 +37,7 @@ func Execute() error {
 		Flags: flagset.RootWithConfig(cfg),
 
 		Before: func(c *cli.Context) error {
+			cfg.Server.Version = version.String
 			return ParseConfig(c, cfg)
 		},
 
@@ -47,6 +48,7 @@ func Execute() error {
 			ListAccounts(cfg),
 			InspectAccount(cfg),
 			RemoveAccount(cfg),
+			PrintVersion(cfg),
 		},
 	}
 

--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -43,6 +43,8 @@ func Server(cfg *config.Config) *cli.Command {
 
 			defer cancel()
 
+			mtrcs.BuildInfo.WithLabelValues(cfg.Server.Version).Set(1)
+
 			handler, err := svc.New(svc.Logger(logger), svc.Config(cfg))
 			if err != nil {
 				logger.Fatal().Err(err).Msg("could not initialize service handler")

--- a/pkg/command/version.go
+++ b/pkg/command/version.go
@@ -1,0 +1,45 @@
+package command
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/micro/cli/v2"
+	"github.com/micro/go-micro/v2/registry/mdns"
+	tw "github.com/olekukonko/tablewriter"
+	"github.com/owncloud/ocis-accounts/pkg/config"
+	"github.com/owncloud/ocis-accounts/pkg/flagset"
+)
+
+// PrintVersion prints the service versions of all running instances.
+func PrintVersion(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name:  "version",
+		Usage: "Print the versions of the running instances",
+		Flags: flagset.ListAccountsWithConfig(cfg),
+		Action: func(c *cli.Context) error {
+			reg := mdns.NewRegistry()
+			services, err := reg.GetService(cfg.GRPC.Namespace + "." + cfg.Server.Name)
+			if err != nil {
+				fmt.Println(fmt.Errorf("could not get accounts services from the registry: %v", err))
+				return err
+			}
+
+			if len(services) == 0 {
+				fmt.Println("No running accounts service found.")
+				return nil
+			}
+
+			table := tw.NewWriter(os.Stdout)
+			table.SetHeader([]string{"Version", "Address", "Id"})
+			table.SetAutoFormatHeaders(false)
+			for _, s := range services {
+				for _, n := range s.Nodes {
+					table.Append([]string{s.Version, n.Address, n.Id})
+				}
+			}
+			table.Render()
+			return nil
+		},
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,7 @@ type GRPC struct {
 
 // Server configures a server.
 type Server struct {
+	Version          string
 	Name             string
 	AccountsDataPath string
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,5 +1,7 @@
 package metrics
 
+import "github.com/prometheus/client_golang/prometheus"
+
 var (
 	// Namespace defines the namespace for the defines metrics.
 	Namespace = "ocis"
@@ -11,12 +13,21 @@ var (
 // Metrics defines the available metrics of this service.
 type Metrics struct {
 	// Counter  *prometheus.CounterVec
+	BuildInfo *prometheus.GaugeVec
 }
 
 // New initializes the available metrics.
 func New() *Metrics {
 	m := &Metrics{
+		BuildInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      "build_info",
+			Help:      "Build information",
+		}, []string{"version"}),
 	}
+
+	_ = prometheus.Register(m.BuildInfo)
 	// TODO: implement metrics
 	return m
 }

--- a/pkg/server/grpc/server.go
+++ b/pkg/server/grpc/server.go
@@ -17,6 +17,7 @@ func Server(opts ...Option) grpc.Service {
 		grpc.Namespace(options.Config.GRPC.Namespace),
 		grpc.Logger(options.Logger),
 		grpc.Flags(options.Flags...),
+		grpc.Version(options.Config.Server.Version),
 	)
 
 	if err := proto.RegisterAccountsServiceHandler(service.Server(), handler); err != nil {

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -18,7 +18,7 @@ func Server(opts ...Option) http.Service {
 	service := http.NewService(
 		http.Logger(options.Logger),
 		http.Name(options.Name),
-		http.Version(version.String),
+		http.Version(options.Config.Server.Version),
 		http.Address(options.Config.HTTP.Addr),
 		http.Namespace(options.Config.HTTP.Namespace),
 		http.Context(options.Context),


### PR DESCRIPTION
The version can now be passed via the config. This allows us to pass the version from ocis to the services if we compile via ocis.
Otherwise the app sets the version itself.