### PR TITLE
[Tests-Only] Disable ARM builds

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -138,19 +138,6 @@ def testing(ctx):
           },
         },
       },
-      {
-        'name': 'sonarcloud',
-        'image': 'sonarsource/sonar-scanner-cli',
-        'pull': 'always',
-        'environment': {
-          'SONAR_TOKEN': {
-            'from_secret': 'sonar_token',
-          },
-          'SONAR_PULL_REQUEST_BASE': 'master' if ctx.build.event == 'pull_request' else None,
-          'SONAR_PULL_REQUEST_BRANCH': ctx.build.source if ctx.build.event == 'pull_request' else None,
-          'SONAR_PULL_REQUEST_KEY': ctx.build.ref.replace("refs/pull/", "").split("/")[0] if ctx.build.event == 'pull_request' else None,
-        },
-      },
     ],
     'volumes': [
       {

--- a/.drone.star
+++ b/.drone.star
@@ -6,8 +6,8 @@ def main(ctx):
 
   stages = [
     docker(ctx, 'amd64'),
-    docker(ctx, 'arm64'),
-    docker(ctx, 'arm'),
+    #docker(ctx, 'arm64'),
+    #docker(ctx, 'arm'),
     binary(ctx, 'linux'),
     binary(ctx, 'darwin'),
     binary(ctx, 'windows'),
@@ -633,8 +633,8 @@ def manifest(ctx):
     ],
     'depends_on': [
       'amd64',
-      'arm64',
-      'arm',
+      #'arm64',
+      #'arm',
       'linux',
       'darwin',
       'windows',


### PR DESCRIPTION
Because internal drone does not yet have ARM agents available.

And remove `sonarcloud` step - it was done as a POC, and would need the various secrets... set up.